### PR TITLE
fix: restore Firebase initialization logic in main.dart

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,18 @@
 import 'package:flutter/material.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:s62_122025_binary_flutterfirebase_interntrack/firebase_options.dart';
 
-void main() {
+void main() async{
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp(
+    options: DefaultFirebaseOptions.currentPlatform,
+  );
   runApp(InternTrackApp());
 }
 
 class InternTrackApp extends StatelessWidget {
+  const InternTrackApp({super.key});
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Restore Firebase initialization in `main()` function

- Add async/await pattern for Firebase setup

- Initialize WidgetsFlutterBinding before Firebase

- Add const constructor to InternTrackApp widget


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["main function"] -- "add async/await" --> B["WidgetsFlutterBinding.ensureInitialized"]
  B -- "initialize" --> C["Firebase.initializeApp"]
  C -- "with options" --> D["DefaultFirebaseOptions.currentPlatform"]
  D -- "then run" --> E["InternTrackApp"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.dart</strong><dd><code>Firebase initialization and widget improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/main.dart

<ul><li>Added Firebase imports and initialization logic<br> <li> Changed <code>main()</code> to async function with proper initialization sequence<br> <li> Added <code>WidgetsFlutterBinding.ensureInitialized()</code> call<br> <li> Added Firebase initialization with platform-specific options<br> <li> Added const constructor to <code>InternTrackApp</code> widget class</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S62-122025-Binary-FlutterFirebase-InternTrack/pull/14/files#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

