### PR TITLE
feat: refactor internship detail mentor feedback into feedback cycles

### DIFF
--- a/lib/models/feedback_cycle_model.dart
+++ b/lib/models/feedback_cycle_model.dart
@@ -1,0 +1,64 @@
+// lib/models/feedback_cycle_model.dart
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class FeedbackCycle {
+  final String id;
+  final String internshipId;
+  final String studentId;
+  final String mentorId;
+  final String studentRequest;
+  final String? mentorFeedback;
+  final String? suggestedNextStep;
+  final String status; // 'pending', 'completed'
+  final DateTime requestedAt;
+  final DateTime? respondedAt;
+  final bool seenByStudent;
+
+  FeedbackCycle({
+    required this.id,
+    required this.internshipId,
+    required this.studentId,
+    required this.mentorId,
+    required this.studentRequest,
+    this.mentorFeedback,
+    this.suggestedNextStep,
+    required this.status,
+    required this.requestedAt,
+    this.respondedAt,
+    this.seenByStudent = false,
+  });
+
+  factory FeedbackCycle.fromFirestore(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
+    return FeedbackCycle(
+      id: doc.id,
+      internshipId: data['internshipId'] ?? '',
+      studentId: data['studentId'] ?? '',
+      mentorId: data['mentorId'] ?? '',
+      studentRequest: data['studentRequest'] ?? '',
+      mentorFeedback: data['mentorFeedback'],
+      suggestedNextStep: data['suggestedNextStep'],
+      status: data['status'] ?? 'pending',
+      requestedAt: (data['requestedAt'] as Timestamp).toDate(),
+      respondedAt: data['respondedAt'] != null 
+          ? (data['respondedAt'] as Timestamp).toDate() 
+          : null,
+      seenByStudent: data['seenByStudent'] ?? false,
+    );
+  }
+
+  Map<String, dynamic> toFirestore() {
+    return {
+      'internshipId': internshipId,
+      'studentId': studentId,
+      'mentorId': mentorId,
+      'studentRequest': studentRequest,
+      'mentorFeedback': mentorFeedback,
+      'suggestedNextStep': suggestedNextStep,
+      'status': status,
+      'requestedAt': Timestamp.fromDate(requestedAt),
+      'respondedAt': respondedAt != null ? Timestamp.fromDate(respondedAt!) : null,
+      'seenByStudent': seenByStudent,
+    };
+  }
+}

--- a/lib/providers/mentor_provider.dart
+++ b/lib/providers/mentor_provider.dart
@@ -1,10 +1,11 @@
 // lib/providers/mentor_provider.dart
+// FIXED: Now uses feedbackCycles instead of feedbackRequests
 import 'package:flutter/material.dart';
 import '../models/mentor_invitation_model.dart';
 import '../models/internship_model.dart';
+import '../models/feedback_cycle_model.dart';
 import '../services/mentor_service.dart';
 import '../services/email_service.dart';
-import '../models/feedback_request_model.dart';
 
 class MentorProvider extends ChangeNotifier {
   final MentorService _mentorService = MentorService();
@@ -12,27 +13,38 @@ class MentorProvider extends ChangeNotifier {
   
   List<MentorStudentLink> _students = [];
   List<Internship> _selectedStudentInternships = [];
+  List<FeedbackCycle> _pendingCycles = [];
   MentorStudentLink? _selectedStudent;
   bool _isLoading = false;
   String? _error;
 
   List<MentorStudentLink> get students => _students;
   List<Internship> get selectedStudentInternships => _selectedStudentInternships;
+  List<FeedbackCycle> get requests => _pendingCycles; // Keep same getter name for compatibility
   MentorStudentLink? get selectedStudent => _selectedStudent;
   bool get isLoading => _isLoading;
   String? get error => _error;
   int get totalInternships => _selectedStudentInternships.length;
 
-List<FeedbackRequest> _requests = [];
-List<FeedbackRequest> get requests => _requests;
+  /// Initialize pending feedback requests for mentor
+  void initializeRequests(String mentorId) {
+    print('MentorProvider: Initializing requests for mentor: $mentorId');
+    
+    _mentorService.getMentorPendingCycles(mentorId).listen(
+      (cycles) {
+        print('MentorProvider: Received ${cycles.length} pending cycles');
+        _pendingCycles = cycles;
+        notifyListeners();
+      },
+      onError: (error) {
+        print('MentorProvider ERROR in requests stream: $error');
+        _error = error.toString();
+        notifyListeners();
+      },
+    );
+  }
 
-void initializeRequests(String mentorId) {
-  _mentorService.getMentorRequests(mentorId).listen((data) {
-    _requests = data;
-    notifyListeners();
-  });
-}
-  // Initialize mentor's students stream
+  /// Initialize mentor's students stream
   void initializeStudentsStream(String mentorId) {
     _isLoading = true;
     notifyListeners();
@@ -52,7 +64,7 @@ void initializeRequests(String mentorId) {
     );
   }
 
-  // Select a student and load their internships
+  /// Select a student and load their internships
   void selectStudent(MentorStudentLink student) {
     _selectedStudent = student;
     notifyListeners();
@@ -69,7 +81,27 @@ void initializeRequests(String mentorId) {
     );
   }
 
-  // Send mentor invitation
+  /// Submit feedback for a cycle
+  Future<void> submitFeedback({
+    required String cycleId,
+    required String feedback,
+    String? nextStep,
+  }) async {
+    try {
+      await _mentorService.submitFeedback(
+        cycleId: cycleId,
+        feedback: feedback,
+        nextStep: nextStep,
+      );
+      // Cycles list will auto-update via stream
+    } catch (e) {
+      _error = e.toString();
+      notifyListeners();
+      rethrow;
+    }
+  }
+
+  /// Send mentor invitation
   Future<bool> sendInvitation({
     required String studentId,
     required String studentName,
@@ -81,7 +113,6 @@ void initializeRequests(String mentorId) {
       _error = null;
       notifyListeners();
 
-      // Send invitation to Firestore
       await _mentorService.sendInvitation(
         studentId: studentId,
         studentName: studentName,
@@ -89,7 +120,6 @@ void initializeRequests(String mentorId) {
         mentorEmail: mentorEmail,
       );
 
-      // Send email notification
       final emailSent = await _emailService.sendMentorInvitation(
         mentorEmail: mentorEmail,
         studentName: studentName,
@@ -108,14 +138,14 @@ void initializeRequests(String mentorId) {
     }
   }
 
-  // Clear selected student
+  /// Clear selected student
   void clearSelectedStudent() {
     _selectedStudent = null;
     _selectedStudentInternships = [];
     notifyListeners();
   }
 
-  // Clear error
+  /// Clear error
   void clearError() {
     _error = null;
     notifyListeners();

--- a/lib/screens/dashboard/mentor_dashboard.dart
+++ b/lib/screens/dashboard/mentor_dashboard.dart
@@ -1,4 +1,5 @@
 // lib/screens/dashboard/mentor_dashboard.dart
+// FIXED: Removed setState during build
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:provider/provider.dart';
@@ -14,8 +15,6 @@ import 'dart:ui';
 import '../profile/mentor_profile_screen.dart';
 import '../mentor/mentor_requests_screen.dart';
 
-
-
 class MentorDashboard extends StatefulWidget {
   @override
   State<MentorDashboard> createState() => _MentorDashboardState();
@@ -24,16 +23,27 @@ class MentorDashboard extends StatefulWidget {
 class _MentorDashboardState extends State<MentorDashboard> {
   int _selectedIndex = 0;
   final FirebaseAuth _auth = FirebaseAuth.instance;
-@override
-void didChangeDependencies() {
-  super.didChangeDependencies();
+  bool _initialized = false;
 
-  final user = _auth.currentUser;
-  if (user != null) {
-    context.read<MentorProvider>().initializeStudentsStream(user.uid);
-    context.read<MentorProvider>().initializeRequests(user.uid);
+  @override
+  void initState() {
+    super.initState();
+    // Initialize in initState instead of didChangeDependencies
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeData();
+    });
   }
-}
+
+  void _initializeData() {
+    if (!_initialized && mounted) {
+      final user = _auth.currentUser;
+      if (user != null) {
+        context.read<MentorProvider>().initializeStudentsStream(user.uid);
+        context.read<MentorProvider>().initializeRequests(user.uid);
+        setState(() => _initialized = true);
+      }
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -284,15 +294,15 @@ void didChangeDependencies() {
     );
   }
 
- Widget _buildProfileView() {
-  return Navigator(
-    onGenerateRoute: (settings) {
-      return MaterialPageRoute(
-        builder: (context) => MentorProfileScreen(),
-      );
-    },
-  );
-}
+  Widget _buildProfileView() {
+    return Navigator(
+      onGenerateRoute: (settings) {
+        return MaterialPageRoute(
+          builder: (context) => MentorProfileScreen(),
+        );
+      },
+    );
+  }
 
   Widget _buildBottomNav(bool isDark) {
     return ClipRRect(
@@ -332,45 +342,43 @@ void didChangeDependencies() {
                 index: 1,
                 isDark: isDark,
               ),
-               Consumer<MentorProvider>(
-  builder: (context, provider, _) {
-    final count = provider.requests.length;
+              Consumer<MentorProvider>(
+                builder: (context, provider, _) {
+                  final count = provider.requests.length;
 
-    return Stack(
-      children: [
-        _buildNavItem(
-          icon: Icons.mark_chat_unread_outlined,
-          label: 'Requests',
-          index: 2,
-          isDark: isDark,
-        ),
+                  return Stack(
+                    children: [
+                      _buildNavItem(
+                        icon: Icons.mark_chat_unread_outlined,
+                        label: 'Requests',
+                        index: 2,
+                        isDark: isDark,
+                      ),
 
-        if (count > 0)
-          Positioned(
-            right: 6,
-            top: 2,
-            child: Container(
-              padding: EdgeInsets.all(6),
-              decoration: BoxDecoration(
-                color: Colors.red,
-                shape: BoxShape.circle,
+                      if (count > 0)
+                        Positioned(
+                          right: 6,
+                          top: 2,
+                          child: Container(
+                            padding: EdgeInsets.all(6),
+                            decoration: BoxDecoration(
+                              color: Colors.red,
+                              shape: BoxShape.circle,
+                            ),
+                            child: Text(
+                              count.toString(),
+                              style: TextStyle(
+                                color: Colors.white,
+                                fontSize: 11,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                        ),
+                    ],
+                  );
+                },
               ),
-              child: Text(
-                count.toString(),
-                style: TextStyle(
-                  color: Colors.white,
-                  fontSize: 11,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-            ),
-          ),
-      ],
-    );
-  },
-),
-
-
               _buildNavItem(
                 icon: Icons.person_outline_rounded,
                 label: 'Profile',
@@ -392,18 +400,20 @@ void didChangeDependencies() {
   }) {
     final isSelected = _selectedIndex == index;
 
-    
-      return GestureDetector(
-  onTap: () {
-    setState(() => _selectedIndex = index);
+    return GestureDetector(
+      onTap: () {
+        setState(() => _selectedIndex = index);
 
-    if (index == 2) {
-      final user = FirebaseAuth.instance.currentUser;
-      if (user != null) {
-        context.read<MentorProvider>().initializeRequests(user.uid);
-      }
-    }
-  },
+        // Refresh requests when switching to requests tab
+        if (index == 2 && !_initialized) {
+          final user = FirebaseAuth.instance.currentUser;
+          if (user != null) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              context.read<MentorProvider>().initializeRequests(user.uid);
+            });
+          }
+        }
+      },
       child: Container(
         padding: EdgeInsets.symmetric(horizontal: 20, vertical: 8),
         decoration: BoxDecoration(

--- a/lib/screens/feedback/feedback_history_screen.dart
+++ b/lib/screens/feedback/feedback_history_screen.dart
@@ -1,0 +1,389 @@
+import 'package:flutter/material.dart';
+import '../../../core/constants/colors.dart';
+import '../../../core/constants/app_constants.dart';
+import '../../../core/widgets/glass_container.dart';
+import '../../../core/widgets/gradient_orb.dart';
+import '../../../models/feedback_cycle_model.dart';
+import '../../../services/feedback_service.dart';
+
+class FeedbackHistoryScreen extends StatelessWidget {
+  final String internshipId;
+  final String internshipCompany;
+  final bool isDark;
+
+  const FeedbackHistoryScreen({
+    Key? key,
+    required this.internshipId,
+    required this.internshipCompany,
+    required this.isDark,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final feedbackService = FeedbackService();
+
+    return Scaffold(
+      body: Stack(
+        children: [
+          GradientOrb(
+            size: 300,
+            alignment: Alignment.topRight,
+            colors: [AppColors.purplePrimary, AppColors.purpleLight],
+            opacity: 0.15,
+          ),
+
+          SafeArea(
+            child: Column(
+              children: [
+                // Header
+                Padding(
+                  padding: EdgeInsets.all(AppConstants.spaceL),
+                  child: Row(
+                    children: [
+                      IconButton(
+                        onPressed: () => Navigator.pop(context),
+                        icon: Icon(Icons.arrow_back_rounded),
+                        style: IconButton.styleFrom(
+                          backgroundColor: isDark
+                              ? Colors.white.withOpacity(0.1)
+                              : Colors.black.withOpacity(0.05),
+                        ),
+                      ),
+                      SizedBox(width: AppConstants.spaceM),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              'Feedback History',
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .displayMedium
+                                  ?.copyWith(fontSize: 24),
+                            ),
+                            SizedBox(height: 4),
+                            Text(
+                              internshipCompany,
+                              style: TextStyle(
+                                fontSize: 14,
+                                color: AppColors.mediumGray,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+
+                // History list
+                Expanded(
+                  child: StreamBuilder<List<FeedbackCycle>>(
+                    stream: feedbackService.getFeedbackHistory(internshipId),
+                    builder: (context, snapshot) {
+                      if (snapshot.connectionState == ConnectionState.waiting) {
+                        return Center(child: CircularProgressIndicator());
+                      }
+
+                      if (!snapshot.hasData || snapshot.data!.isEmpty) {
+                        return Center(
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              Icon(
+                                Icons.history,
+                                size: 64,
+                                color: AppColors.mediumGray.withOpacity(0.5),
+                              ),
+                              SizedBox(height: AppConstants.spaceL),
+                              Text(
+                                'No feedback history',
+                                style: TextStyle(
+                                  fontSize: 18,
+                                  fontWeight: FontWeight.w600,
+                                  color: isDark
+                                      ? AppColors.pureWhite
+                                      : AppColors.pureBlack,
+                                ),
+                              ),
+                              SizedBox(height: AppConstants.spaceS),
+                              Text(
+                                'Your feedback cycles will appear here',
+                                style: TextStyle(
+                                  fontSize: 14,
+                                  color: AppColors.mediumGray,
+                                ),
+                              ),
+                            ],
+                          ),
+                        );
+                      }
+
+                      final cycles = snapshot.data!;
+
+                      return ListView.builder(
+                        padding: EdgeInsets.all(AppConstants.spaceL),
+                        itemCount: cycles.length,
+                        itemBuilder: (context, index) {
+                          final cycle = cycles[index];
+                          final isLatest = index == 0;
+
+                          return Padding(
+                            padding: EdgeInsets.only(
+                              bottom: AppConstants.spaceM,
+                            ),
+                            child: _FeedbackCycleCard(
+                              cycle: cycle,
+                              isDark: isDark,
+                              isLatest: isLatest,
+                            ),
+                          );
+                        },
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FeedbackCycleCard extends StatelessWidget {
+  final FeedbackCycle cycle;
+  final bool isDark;
+  final bool isLatest;
+
+  const _FeedbackCycleCard({
+    Key? key,
+    required this.cycle,
+    required this.isDark,
+    required this.isLatest,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final isCompleted = cycle.status == 'completed';
+
+    return GlassContainer(
+      isDark: isDark,
+      padding: EdgeInsets.all(AppConstants.spaceL),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Header
+          Row(
+            children: [
+              Container(
+                padding: EdgeInsets.all(8),
+                decoration: BoxDecoration(
+                  color: isCompleted
+                      ? AppColors.purplePrimary.withOpacity(0.2)
+                      : Colors.orange.withOpacity(0.2),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Icon(
+                  isCompleted ? Icons.check_circle : Icons.access_time,
+                  color: isCompleted ? AppColors.purplePrimary : Colors.orange,
+                  size: 18,
+                ),
+              ),
+              SizedBox(width: AppConstants.spaceM),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Text(
+                          isCompleted ? 'Completed' : 'Pending',
+                          style: TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.w600,
+                            color: isDark
+                                ? AppColors.pureWhite
+                                : AppColors.pureBlack,
+                          ),
+                        ),
+                        if (isLatest) ...[
+                          SizedBox(width: 8),
+                          Container(
+                            padding: EdgeInsets.symmetric(
+                              horizontal: 6,
+                              vertical: 2,
+                            ),
+                            decoration: BoxDecoration(
+                              gradient: LinearGradient(
+                                colors: [
+                                  AppColors.purplePrimary,
+                                  AppColors.purpleLight
+                                ],
+                              ),
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                            child: Text(
+                              'LATEST',
+                              style: TextStyle(
+                                fontSize: 9,
+                                fontWeight: FontWeight.w700,
+                                color: Colors.white,
+                                letterSpacing: 0.5,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                    SizedBox(height: 2),
+                    Text(
+                      _formatDate(cycle.requestedAt),
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: AppColors.mediumGray,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+
+          SizedBox(height: AppConstants.spaceM),
+          Divider(color: AppColors.mediumGray.withOpacity(0.2)),
+          SizedBox(height: AppConstants.spaceM),
+
+          // Student request
+          Text(
+            'Your Request:',
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              color: AppColors.mediumGray,
+            ),
+          ),
+          SizedBox(height: AppConstants.spaceS),
+          Text(
+            cycle.studentRequest,
+            style: TextStyle(
+              fontSize: 13,
+              color: isDark ? AppColors.pureWhite : AppColors.pureBlack,
+            ),
+          ),
+
+          // Mentor feedback (if completed)
+          if (isCompleted && cycle.mentorFeedback != null) ...[
+            SizedBox(height: AppConstants.spaceM),
+            Text(
+              'Mentor Response:',
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+                color: AppColors.mediumGray,
+              ),
+            ),
+            SizedBox(height: AppConstants.spaceS),
+            Container(
+              padding: EdgeInsets.all(AppConstants.spaceM),
+              decoration: BoxDecoration(
+                color: AppColors.purplePrimary.withOpacity(0.1),
+                borderRadius: BorderRadius.circular(10),
+                border: Border.all(
+                  color: AppColors.purplePrimary.withOpacity(0.3),
+                ),
+              ),
+              child: Text(
+                cycle.mentorFeedback!,
+                style: TextStyle(
+                  fontSize: 13,
+                  height: 1.4,
+                  color: isDark ? AppColors.pureWhite : AppColors.pureBlack,
+                ),
+              ),
+            ),
+
+            if (cycle.suggestedNextStep != null &&
+                cycle.suggestedNextStep!.isNotEmpty) ...[
+              SizedBox(height: AppConstants.spaceM),
+              Container(
+                padding: EdgeInsets.all(AppConstants.spaceM),
+                decoration: BoxDecoration(
+                  color: Colors.green.withOpacity(0.1),
+                  borderRadius: BorderRadius.circular(10),
+                  border: Border.all(
+                    color: Colors.green.withOpacity(0.3),
+                  ),
+                ),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Icon(
+                      Icons.arrow_forward,
+                      color: Colors.green,
+                      size: 16,
+                    ),
+                    SizedBox(width: AppConstants.spaceS),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'Next Step',
+                            style: TextStyle(
+                              fontSize: 11,
+                              fontWeight: FontWeight.w600,
+                              color: Colors.green,
+                            ),
+                          ),
+                          SizedBox(height: 2),
+                          Text(
+                            cycle.suggestedNextStep!,
+                            style: TextStyle(
+                              fontSize: 12,
+                              color: isDark
+                                  ? AppColors.pureWhite
+                                  : AppColors.pureBlack,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+
+            SizedBox(height: AppConstants.spaceS),
+            Text(
+              'Responded ${_formatDate(cycle.respondedAt!)}',
+              style: TextStyle(
+                fontSize: 11,
+                color: AppColors.mediumGray,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  String _formatDate(DateTime date) {
+    final now = DateTime.now();
+    final diff = now.difference(date);
+
+    if (diff.inDays == 0) {
+      if (diff.inHours == 0) {
+        return '${diff.inMinutes}m ago';
+      }
+      return '${diff.inHours}h ago';
+    } else if (diff.inDays == 1) {
+      return 'Yesterday';
+    } else if (diff.inDays < 7) {
+      return '${diff.inDays}d ago';
+    } else {
+      return '${date.day}/${date.month}/${date.year}';
+    }
+  }
+}

--- a/lib/screens/feedback/request_feedback_screen.dart
+++ b/lib/screens/feedback/request_feedback_screen.dart
@@ -1,0 +1,401 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../../../core/constants/colors.dart';
+import '../../../core/constants/app_constants.dart';
+import '../../../core/widgets/gradient_orb.dart';
+import '../../../services/feedback_service.dart';
+
+class RequestFeedbackScreen extends StatefulWidget {
+  final String internshipId;
+  final String internshipCompany;
+  final bool isDark;
+
+  const RequestFeedbackScreen({
+    Key? key,
+    required this.internshipId,
+    required this.internshipCompany,
+    required this.isDark,
+  }) : super(key: key);
+
+  @override
+  State<RequestFeedbackScreen> createState() => _RequestFeedbackScreenState();
+}
+
+class _RequestFeedbackScreenState extends State<RequestFeedbackScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _requestController = TextEditingController();
+  final _mentorEmailController = TextEditingController();
+  final FeedbackService _feedbackService = FeedbackService();
+  final FirebaseAuth _auth = FirebaseAuth.instance;
+  bool _isLoading = false;
+
+  @override
+  void dispose() {
+    _requestController.dispose();
+    _mentorEmailController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submitRequest() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    setState(() => _isLoading = true);
+
+    try {
+      // Get mentor ID by email
+      final mentorSnapshot = await FirebaseFirestore.instance
+          .collection('users')
+          .where('email', isEqualTo: _mentorEmailController.text.trim())
+          .where('role', isEqualTo: 'mentor')
+          .limit(1)
+          .get();
+
+      if (mentorSnapshot.docs.isEmpty) {
+        throw 'Mentor not found with this email';
+      }
+
+      final mentorId = mentorSnapshot.docs.first.id;
+      final studentId = _auth.currentUser!.uid;
+
+      await _feedbackService.createFeedbackRequest(
+        internshipId: widget.internshipId,
+        studentId: studentId,
+        mentorId: mentorId,
+        studentRequest: _requestController.text.trim(),
+      );
+
+      if (mounted) {
+        // Show success dialog
+        showDialog(
+          context: context,
+          barrierDismissible: false,
+          builder: (_) => AlertDialog(
+            backgroundColor: AppColors.purplePrimary,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(18),
+            ),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  Icons.check_circle_outline,
+                  size: 48,
+                  color: Colors.white,
+                ),
+                SizedBox(height: 12),
+                Text(
+                  'Request Sent!',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 18,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                SizedBox(height: 8),
+                Text(
+                  'Your mentor will be notified',
+                  style: TextStyle(
+                    color: Colors.white.withOpacity(0.9),
+                    fontSize: 14,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          ),
+        );
+
+        Future.delayed(Duration(seconds: 2), () {
+          if (mounted) {
+            Navigator.pop(context); // Close dialog
+            Navigator.pop(context, true); // Close screen with success
+          }
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(e.toString()),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Stack(
+        children: [
+          GradientOrb(
+            size: 300,
+            alignment: Alignment.topRight,
+            colors: [AppColors.purplePrimary, AppColors.purpleLight],
+            opacity: 0.15,
+          ),
+
+          SafeArea(
+            child: Column(
+              children: [
+                // Header
+                Padding(
+                  padding: EdgeInsets.all(AppConstants.spaceL),
+                  child: Row(
+                    children: [
+                      IconButton(
+                        onPressed: () => Navigator.pop(context),
+                        icon: Icon(Icons.arrow_back_rounded),
+                        style: IconButton.styleFrom(
+                          backgroundColor: widget.isDark
+                              ? Colors.white.withOpacity(0.1)
+                              : Colors.black.withOpacity(0.05),
+                        ),
+                      ),
+                      SizedBox(width: AppConstants.spaceM),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              'Request Feedback',
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .displayMedium
+                                  ?.copyWith(fontSize: 24),
+                            ),
+                            SizedBox(height: 4),
+                            Text(
+                              widget.internshipCompany,
+                              style: TextStyle(
+                                fontSize: 14,
+                                color: AppColors.mediumGray,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+
+                Expanded(
+                  child: SingleChildScrollView(
+                    padding: EdgeInsets.all(AppConstants.spaceL),
+                    child: Form(
+                      key: _formKey,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          // Info box
+                          Container(
+                            padding: EdgeInsets.all(AppConstants.spaceM),
+                            decoration: BoxDecoration(
+                              color: AppColors.purplePrimary.withOpacity(0.1),
+                              borderRadius: BorderRadius.circular(12),
+                              border: Border.all(
+                                color: AppColors.purplePrimary.withOpacity(0.3),
+                              ),
+                            ),
+                            child: Row(
+                              children: [
+                                Icon(
+                                  Icons.info_outline,
+                                  color: AppColors.purplePrimary,
+                                  size: 20,
+                                ),
+                                SizedBox(width: AppConstants.spaceM),
+                                Expanded(
+                                  child: Text(
+                                    'Your mentor will receive a notification and can respond with structured feedback',
+                                    style: TextStyle(
+                                      fontSize: 13,
+                                      color: widget.isDark
+                                          ? AppColors.pureWhite
+                                          : AppColors.pureBlack,
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+
+                          SizedBox(height: AppConstants.spaceXL),
+
+                          // Mentor email field
+                          Text(
+                            'Mentor Email',
+                            style: TextStyle(
+                              fontSize: 14,
+                              fontWeight: FontWeight.w600,
+                              color: widget.isDark
+                                  ? AppColors.pureWhite
+                                  : AppColors.pureBlack,
+                            ),
+                          ),
+                          SizedBox(height: AppConstants.spaceS),
+                          TextFormField(
+                            controller: _mentorEmailController,
+                            keyboardType: TextInputType.emailAddress,
+                            style: TextStyle(
+                              color: widget.isDark
+                                  ? AppColors.pureWhite
+                                  : AppColors.pureBlack,
+                            ),
+                            decoration: InputDecoration(
+                              hintText: 'mentor@example.com',
+                              hintStyle: TextStyle(color: AppColors.mediumGray),
+                              prefixIcon: Icon(
+                                Icons.email_outlined,
+                                color: AppColors.mediumGray,
+                              ),
+                              filled: true,
+                              fillColor: widget.isDark
+                                  ? Colors.white.withOpacity(0.1)
+                                  : Colors.black.withOpacity(0.05),
+                              border: OutlineInputBorder(
+                                borderRadius:
+                                    BorderRadius.circular(AppConstants.radiusMedium),
+                                borderSide: BorderSide.none,
+                              ),
+                              enabledBorder: OutlineInputBorder(
+                                borderRadius:
+                                    BorderRadius.circular(AppConstants.radiusMedium),
+                                borderSide: BorderSide(
+                                  color: widget.isDark
+                                      ? Colors.white.withOpacity(0.2)
+                                      : Colors.black.withOpacity(0.1),
+                                ),
+                              ),
+                              focusedBorder: OutlineInputBorder(
+                                borderRadius:
+                                    BorderRadius.circular(AppConstants.radiusMedium),
+                                borderSide: BorderSide(
+                                  color: AppColors.purplePrimary,
+                                  width: 2,
+                                ),
+                              ),
+                            ),
+                            validator: (value) {
+                              if (value == null || value.trim().isEmpty) {
+                                return 'Please enter mentor email';
+                              }
+                              if (!value.contains('@') || !value.contains('.')) {
+                                return 'Please enter a valid email';
+                              }
+                              return null;
+                            },
+                          ),
+
+                          SizedBox(height: AppConstants.spaceL),
+
+                          // Request message field
+                          Text(
+                            'Your Request',
+                            style: TextStyle(
+                              fontSize: 14,
+                              fontWeight: FontWeight.w600,
+                              color: widget.isDark
+                                  ? AppColors.pureWhite
+                                  : AppColors.pureBlack,
+                            ),
+                          ),
+                          SizedBox(height: AppConstants.spaceS),
+                          TextFormField(
+                            controller: _requestController,
+                            maxLines: 8,
+                            style: TextStyle(
+                              color: widget.isDark
+                                  ? AppColors.pureWhite
+                                  : AppColors.pureBlack,
+                            ),
+                            decoration: InputDecoration(
+                              hintText:
+                                  'What would you like feedback on?\n\nExamples:\n• How can I improve my resume?\n• Advice for the upcoming interview?\n• Should I accept this offer?',
+                              hintStyle: TextStyle(color: AppColors.mediumGray),
+                              filled: true,
+                              fillColor: widget.isDark
+                                  ? Colors.white.withOpacity(0.1)
+                                  : Colors.black.withOpacity(0.05),
+                              border: OutlineInputBorder(
+                                borderRadius:
+                                    BorderRadius.circular(AppConstants.radiusMedium),
+                                borderSide: BorderSide.none,
+                              ),
+                              enabledBorder: OutlineInputBorder(
+                                borderRadius:
+                                    BorderRadius.circular(AppConstants.radiusMedium),
+                                borderSide: BorderSide(
+                                  color: widget.isDark
+                                      ? Colors.white.withOpacity(0.2)
+                                      : Colors.black.withOpacity(0.1),
+                                ),
+                              ),
+                              focusedBorder: OutlineInputBorder(
+                                borderRadius:
+                                    BorderRadius.circular(AppConstants.radiusMedium),
+                                borderSide: BorderSide(
+                                  color: AppColors.purplePrimary,
+                                  width: 2,
+                                ),
+                              ),
+                            ),
+                            validator: (value) {
+                              if (value == null || value.trim().isEmpty) {
+                                return 'Please describe what you need feedback on';
+                              }
+                              if (value.trim().length < 10) {
+                                return 'Please provide more details (at least 10 characters)';
+                              }
+                              return null;
+                            },
+                          ),
+
+                          SizedBox(height: AppConstants.spaceXL),
+
+                          // Submit button
+                          SizedBox(
+                            width: double.infinity,
+                            child: ElevatedButton.icon(
+                              onPressed: _isLoading ? null : _submitRequest,
+                              icon: _isLoading
+                                  ? SizedBox(
+                                      width: 18,
+                                      height: 18,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 2,
+                                        valueColor:
+                                            AlwaysStoppedAnimation<Color>(Colors.white),
+                                      ),
+                                    )
+                                  : Icon(Icons.send, size: 18),
+                              label: Text(_isLoading ? 'Sending...' : 'Send Request'),
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: AppColors.purplePrimary,
+                                foregroundColor: Colors.white,
+                                padding: EdgeInsets.symmetric(vertical: 16),
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(14),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/feedback/widget/mentor_feedback_widget.dart
+++ b/lib/screens/feedback/widget/mentor_feedback_widget.dart
@@ -1,0 +1,450 @@
+import 'package:flutter/material.dart';
+import '../../../core/constants/colors.dart';
+import '../../../core/constants/app_constants.dart';
+import '../../../core/widgets/glass_container.dart';
+import '../../../models/feedback_cycle_model.dart';
+import '../../../services/feedback_service.dart';
+import '../feedback_history_screen.dart';
+import '../request_feedback_screen.dart';
+
+class MentorFeedbackWidget extends StatefulWidget {
+  final String internshipId;
+  final String internshipCompany;
+  final bool isDark;
+
+  const MentorFeedbackWidget({
+    Key? key,
+    required this.internshipId,
+    required this.internshipCompany,
+    required this.isDark,
+  }) : super(key: key);
+
+  @override
+  State<MentorFeedbackWidget> createState() => _MentorFeedbackWidgetState();
+}
+
+class _MentorFeedbackWidgetState extends State<MentorFeedbackWidget> {
+  final FeedbackService _feedbackService = FeedbackService();
+  FeedbackCycle? _latestFeedback;
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadLatestFeedback();
+  }
+
+  Future<void> _loadLatestFeedback() async {
+    setState(() => _isLoading = true);
+    final feedback = await _feedbackService.getLatestFeedback(widget.internshipId);
+    if (mounted) {
+      setState(() {
+        _latestFeedback = feedback;
+        _isLoading = false;
+      });
+
+      // Mark as seen if completed and not seen yet
+      if (feedback != null && 
+          feedback.status == 'completed' && 
+          !feedback.seenByStudent) {
+        _feedbackService.markFeedbackAsSeen(feedback.id);
+      }
+    }
+  }
+
+  void _requestFeedback() async {
+    final result = await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => RequestFeedbackScreen(
+          internshipId: widget.internshipId,
+          internshipCompany: widget.internshipCompany,
+          isDark: widget.isDark,
+        ),
+      ),
+    );
+
+    if (result == true) {
+      _loadLatestFeedback();
+    }
+  }
+
+  void _viewHistory() {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => FeedbackHistoryScreen(
+          internshipId: widget.internshipId,
+          internshipCompany: widget.internshipCompany,
+          isDark: widget.isDark,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              'Mentor Feedback',
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            if (_latestFeedback != null)
+              TextButton.icon(
+                onPressed: _viewHistory,
+                icon: Icon(Icons.history, size: 18),
+                label: Text('View History'),
+                style: TextButton.styleFrom(
+                  foregroundColor: AppColors.purplePrimary,
+                ),
+              ),
+          ],
+        ),
+        SizedBox(height: AppConstants.spaceM),
+
+        if (_isLoading)
+          Center(
+            child: Padding(
+              padding: EdgeInsets.all(AppConstants.spaceXL),
+              child: CircularProgressIndicator(),
+            ),
+          )
+        else if (_latestFeedback == null)
+          _buildNoFeedbackState()
+        else if (_latestFeedback!.status == 'pending')
+          _buildPendingState()
+        else
+          _buildCompletedFeedback(),
+      ],
+    );
+  }
+
+  Widget _buildNoFeedbackState() {
+    return GlassContainer(
+      isDark: widget.isDark,
+      padding: EdgeInsets.all(AppConstants.spaceL),
+      child: Column(
+        children: [
+          Icon(
+            Icons.forum_outlined,
+            size: 48,
+            color: AppColors.mediumGray.withOpacity(0.5),
+          ),
+          SizedBox(height: AppConstants.spaceM),
+          Text(
+            'No feedback yet',
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w600,
+              color: widget.isDark ? AppColors.pureWhite : AppColors.pureBlack,
+            ),
+          ),
+          SizedBox(height: AppConstants.spaceS),
+          Text(
+            'Request feedback from your mentor to get started',
+            style: TextStyle(
+              fontSize: 14,
+              color: AppColors.mediumGray,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          SizedBox(height: AppConstants.spaceL),
+          SizedBox(
+            width: double.infinity,
+            child: ElevatedButton.icon(
+              onPressed: _requestFeedback,
+              icon: Icon(Icons.send_outlined, size: 18),
+              label: Text('Request Mentor Feedback'),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.purplePrimary,
+                foregroundColor: Colors.white,
+                padding: EdgeInsets.symmetric(vertical: 14),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPendingState() {
+    return GlassContainer(
+      isDark: widget.isDark,
+      padding: EdgeInsets.all(AppConstants.spaceL),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                padding: EdgeInsets.all(8),
+                decoration: BoxDecoration(
+                  color: Colors.orange.withOpacity(0.2),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Icon(
+                  Icons.access_time,
+                  color: Colors.orange,
+                  size: 20,
+                ),
+              ),
+              SizedBox(width: AppConstants.spaceM),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Feedback Pending',
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w600,
+                        color: widget.isDark ? AppColors.pureWhite : AppColors.pureBlack,
+                      ),
+                    ),
+                    SizedBox(height: 4),
+                    Text(
+                      'Waiting for mentor response',
+                      style: TextStyle(
+                        fontSize: 13,
+                        color: AppColors.mediumGray,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          SizedBox(height: AppConstants.spaceM),
+          Divider(color: AppColors.mediumGray.withOpacity(0.2)),
+          SizedBox(height: AppConstants.spaceM),
+          Text(
+            'Your Request:',
+            style: TextStyle(
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+              color: AppColors.mediumGray,
+            ),
+          ),
+          SizedBox(height: AppConstants.spaceS),
+          Text(
+            _latestFeedback!.studentRequest,
+            style: TextStyle(
+              fontSize: 14,
+              color: widget.isDark ? AppColors.pureWhite : AppColors.pureBlack,
+            ),
+          ),
+          SizedBox(height: AppConstants.spaceM),
+          Text(
+            'Requested ${_formatDate(_latestFeedback!.requestedAt)}',
+            style: TextStyle(
+              fontSize: 12,
+              color: AppColors.mediumGray,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCompletedFeedback() {
+    final hasNewFeedback = !_latestFeedback!.seenByStudent;
+
+    return Column(
+      children: [
+        GlassContainer(
+          isDark: widget.isDark,
+          padding: EdgeInsets.all(AppConstants.spaceL),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Container(
+                    padding: EdgeInsets.all(8),
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        colors: [AppColors.purplePrimary, AppColors.purpleLight],
+                      ),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Icon(
+                      Icons.psychology_outlined,
+                      color: Colors.white,
+                      size: 20,
+                    ),
+                  ),
+                  SizedBox(width: AppConstants.spaceM),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            Text(
+                              'Latest Feedback',
+                              style: TextStyle(
+                                fontSize: 16,
+                                fontWeight: FontWeight.w600,
+                                color: widget.isDark ? AppColors.pureWhite : AppColors.pureBlack,
+                              ),
+                            ),
+                            if (hasNewFeedback) ...[
+                              SizedBox(width: 8),
+                              Container(
+                                padding: EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                                decoration: BoxDecoration(
+                                  color: Colors.green,
+                                  borderRadius: BorderRadius.circular(10),
+                                ),
+                                child: Text(
+                                  'NEW',
+                                  style: TextStyle(
+                                    fontSize: 10,
+                                    fontWeight: FontWeight.w700,
+                                    color: Colors.white,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ],
+                        ),
+                        SizedBox(height: 4),
+                        Text(
+                          'From your mentor • ${_formatDate(_latestFeedback!.respondedAt!)}',
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: AppColors.mediumGray,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+              
+              SizedBox(height: AppConstants.spaceL),
+              
+              // Mentor's feedback
+              Container(
+                padding: EdgeInsets.all(AppConstants.spaceM),
+                decoration: BoxDecoration(
+                  color: AppColors.purplePrimary.withOpacity(0.1),
+                  borderRadius: BorderRadius.circular(12),
+                  border: Border.all(
+                    color: AppColors.purplePrimary.withOpacity(0.3),
+                    width: 1,
+                  ),
+                ),
+                child: Text(
+                  _latestFeedback!.mentorFeedback ?? '',
+                  style: TextStyle(
+                    fontSize: 14,
+                    height: 1.5,
+                    color: widget.isDark ? AppColors.pureWhite : AppColors.pureBlack,
+                  ),
+                ),
+              ),
+              
+              // Suggested next step
+              if (_latestFeedback!.suggestedNextStep != null &&
+                  _latestFeedback!.suggestedNextStep!.isNotEmpty) ...[
+                SizedBox(height: AppConstants.spaceM),
+                Container(
+                  padding: EdgeInsets.all(AppConstants.spaceM),
+                  decoration: BoxDecoration(
+                    color: Colors.green.withOpacity(0.1),
+                    borderRadius: BorderRadius.circular(12),
+                    border: Border.all(
+                      color: Colors.green.withOpacity(0.3),
+                      width: 1,
+                    ),
+                  ),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Icon(
+                        Icons.arrow_forward,
+                        color: Colors.green,
+                        size: 18,
+                      ),
+                      SizedBox(width: AppConstants.spaceS),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              'Suggested Next Step',
+                              style: TextStyle(
+                                fontSize: 12,
+                                fontWeight: FontWeight.w600,
+                                color: Colors.green,
+                              ),
+                            ),
+                            SizedBox(height: 4),
+                            Text(
+                              _latestFeedback!.suggestedNextStep!,
+                              style: TextStyle(
+                                fontSize: 13,
+                                color: widget.isDark ? AppColors.pureWhite : AppColors.pureBlack,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+
+        SizedBox(height: AppConstants.spaceM),
+
+        // Action button
+        SizedBox(
+          width: double.infinity,
+          child: OutlinedButton.icon(
+            onPressed: _requestFeedback,
+            icon: Icon(Icons.refresh, size: 18),
+            label: Text('Request Follow-up Feedback'),
+            style: OutlinedButton.styleFrom(
+              foregroundColor: AppColors.purplePrimary,
+              side: BorderSide(color: AppColors.purplePrimary),
+              padding: EdgeInsets.symmetric(vertical: 14),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  String _formatDate(DateTime date) {
+    final now = DateTime.now();
+    final diff = now.difference(date);
+
+    if (diff.inDays == 0) {
+      if (diff.inHours == 0) {
+        return '${diff.inMinutes}m ago';
+      }
+      return '${diff.inHours}h ago';
+    } else if (diff.inDays == 1) {
+      return 'Yesterday';
+    } else if (diff.inDays < 7) {
+      return '${diff.inDays}d ago';
+    } else {
+      return '${date.day}/${date.month}/${date.year}';
+    }
+  }
+}

--- a/lib/screens/internships/internship_detail_screen.dart
+++ b/lib/screens/internships/internship_detail_screen.dart
@@ -1,4 +1,3 @@
-// lib/screens/internships/internship_detail_screen.dart
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '../../core/constants/colors.dart';
@@ -7,6 +6,7 @@ import '../../core/widgets/glass_container.dart';
 import '../../core/widgets/gradient_orb.dart';
 import '../../models/internship_model.dart';
 import '../../app/app_routes.dart';
+import '../feedback/widget/mentor_feedback_widget.dart';
 import 'dart:ui';
 import 'package:firebase_auth/firebase_auth.dart';
 
@@ -22,7 +22,6 @@ class InternshipDetailScreen extends StatefulWidget {
 class _InternshipDetailScreenState extends State<InternshipDetailScreen> {
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
   final TextEditingController _reflectionController = TextEditingController();
-  String _feedbackMessage = '';
   final TextEditingController _learningController = TextEditingController();
   
   final List<String> _availableSkills = [
@@ -102,7 +101,6 @@ class _InternshipDetailScreenState extends State<InternshipDetailScreen> {
     }
   }
 
-
   Future<void> _saveReflection() async {
     try {
       await _firestore.collection('internships').doc(widget.internship.id).update({
@@ -122,108 +120,6 @@ class _InternshipDetailScreenState extends State<InternshipDetailScreen> {
       }
     }
   }
-
-  
-void _requestMentorFeedback() {
-  final emailCtrl = TextEditingController();
-  final messageCtrl = TextEditingController();
-
-  showDialog(
-    context: context,
-    builder: (_) => AlertDialog(
-      title: const Text('Request Mentor Feedback'),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          TextField(
-            controller: emailCtrl,
-            decoration: const InputDecoration(labelText: 'Mentor Email'),
-          ),
-          const SizedBox(height: 8),
-          TextField(
-            controller: messageCtrl,
-            maxLines: 3,
-            decoration: const InputDecoration(labelText: 'Message'),
-          ),
-        ],
-      ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.pop(context),
-          child: const Text('Cancel'),
-        ),
-
-        ElevatedButton(
-          onPressed: () async {
-            final mentorQuery = await FirebaseFirestore.instance
-                .collection('users')
-                .where('email', isEqualTo: emailCtrl.text.trim())
-                .where('role', isEqualTo: 'mentor')
-                .limit(1)
-                .get();
-
-            if (mentorQuery.docs.isEmpty) {
-              ScaffoldMessenger.of(context)
-                  .showSnackBar(const SnackBar(content: Text('Mentor not found')));
-              return;
-            }
-
-            final mentorId = mentorQuery.docs.first.id;
-            final student = FirebaseAuth.instance.currentUser!;
-
-            await FirebaseFirestore.instance.collection('feedbackRequests').add({
-              'mentorId': mentorId,
-              'studentId': student.uid,
-               'studentName': FirebaseAuth.instance.currentUser!.displayName ?? "Student",
-  'company': widget.internship.company,
-              'internshipId': widget.internship.id,
-              'message': messageCtrl.text.trim(),
-              'status': 'pending',
-              'createdAt': Timestamp.now(),
-            });
-
-            Navigator.pop(context);
-
-            showDialog(
-              context: context,
-              barrierDismissible: false,
-              builder: (_) => AlertDialog(
-                backgroundColor: AppColors.purplePrimary,
-                shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(18)),
-                content: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: const [
-                    Icon(Icons.check_circle_outline,
-                        size: 48, color: Colors.white),
-                    SizedBox(height: 12),
-                    Text(
-                      "Request sent to mentor",
-                      style: TextStyle(
-                        color: Colors.white,
-                        fontSize: 16,
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            );
-
-            Future.delayed(const Duration(seconds: 2), () {
-              Navigator.pop(context);
-            });
-          },
-          child: const Text('Send'),
-        ),
-      ],
-    ),
-  );
-}
-
-
-
-
 
   Future<void> _saveLearning() async {
     try {
@@ -250,27 +146,7 @@ void _requestMentorFeedback() {
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     
-      return Scaffold(
-  bottomNavigationBar: Padding(
-    padding: const EdgeInsets.all(16),
-    child: SizedBox(
-      height: 52,
-      child: ElevatedButton(
-        style: ElevatedButton.styleFrom(
-          backgroundColor: AppColors.purplePrimary,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(14),
-          ),
-        ),
-        onPressed: _requestMentorFeedback,
-        child: const Text(
-          "Request Mentor Feedback",
-          style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600, color: Colors.white,),
-          
-        ),
-      ),
-    ),
-  ),
+    return Scaffold(
       body: Stack(
         children: [
           GradientOrb(
@@ -419,14 +295,30 @@ void _requestMentorFeedback() {
                             ],
                           ),
                         ),
-//                         ElevatedButton(
-//   onPressed: _requestMentorFeedback,
-//   child: const Text('Request Mentor Feedback'),
-// ),  
 
                         SizedBox(height: AppConstants.spaceL),
 
-                        // Timeline
+                        if (widget.internship.description != null) ...[
+                          Text(
+                            'Description',
+                            style: Theme.of(context).textTheme.headlineSmall,
+                          ),
+                          SizedBox(height: AppConstants.spaceM),
+                          GlassContainer(
+                            isDark: isDark,
+                            padding: EdgeInsets.all(AppConstants.spaceM),
+                            child: Text(
+                              widget.internship.description!,
+                              style: TextStyle(
+                                fontSize: 15,
+                                color: isDark ? AppColors.pureWhite : AppColors.pureBlack,
+                                height: 1.5,
+                              ),
+                            ),
+                          ),
+                          SizedBox(height: AppConstants.spaceL),
+                        ],
+
                         if (widget.internship.timeline.isNotEmpty) ...[
                           Text(
                             'Timeline',
@@ -437,7 +329,6 @@ void _requestMentorFeedback() {
                           SizedBox(height: AppConstants.spaceL),
                         ],
 
-                        // Reflection Notes
                         Text(
                           'Personal Reflections',
                           style: Theme.of(context).textTheme.headlineSmall,
@@ -447,79 +338,21 @@ void _requestMentorFeedback() {
 
                         SizedBox(height: AppConstants.spaceL),
 
-                        // Learning Outcomes
                         Text(
                           'Learning & Growth',
                           style: Theme.of(context).textTheme.headlineSmall,
                         ),
                         SizedBox(height: AppConstants.spaceM),
                         _buildLearningSection(isDark),
+                        
                         SizedBox(height: AppConstants.spaceL),
-StreamBuilder(
-  stream: FirebaseFirestore.instance
-      .collection('feedbackRequests')
-      .where('internshipId', isEqualTo: widget.internship.id)
-      .where('status', isEqualTo: 'completed')
-      .snapshots(),
-  builder: (context, snapshot) {
-    if (!snapshot.hasData || snapshot.data!.docs.isEmpty) return SizedBox();
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text("Mentor Feedback", style: Theme.of(context).textTheme.headlineSmall),
-        SizedBox(height: 12),
-
-       GlassContainer(
-  isDark: isDark,
-  padding: EdgeInsets.all(16),
-  child: Column(
-    crossAxisAlignment: CrossAxisAlignment.start,
-    children: snapshot.data!.docs.map((doc) {
-      return Padding(
-        padding: const EdgeInsets.only(bottom: 16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-
-            Text(
-              "You:",
-              style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.w600,
-                    color: isDark ? AppColors.pureWhite : AppColors.pureBlack,
-                  ),
-            ),
-            const SizedBox(height: 4),
-            Text(  (doc.data() as Map<String, dynamic>)['message'] ??
-  (doc.data() as Map<String, dynamic>)['studentMessage'] ??
-  '',),
-
-            const SizedBox(height: 8),
-
-            Text(
-              "Mentor:",
-              style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.w600,
-                    color: isDark ? AppColors.pureWhite : AppColors.pureBlack,
-                  ),
-            ),
-            const SizedBox(height: 4),
-            Text(doc['mentorFeedback'] ?? ''),
-
-            const Divider(height: 24),
-          ],
-        ),
-      );
-    }).toList(),
-  ),
-),
-
-      ],
-    );
-  },
-),
+                        // UPDATED: Replace old feedback section with new widget
+                        MentorFeedbackWidget(
+                          internshipId: widget.internship.id,
+                          internshipCompany: widget.internship.company,
+                          isDark: isDark,
+                        ),
 
                         SizedBox(height: AppConstants.spaceXL),
                       ],
@@ -534,6 +367,7 @@ StreamBuilder(
     );
   }
 
+  // All the existing helper methods remain the same...
   Widget _buildTimeline(bool isDark) {
     return GlassContainer(
       isDark: isDark,
@@ -735,7 +569,6 @@ StreamBuilder(
           ),
           SizedBox(height: AppConstants.spaceM),
           
-          // Skills
           Text(
             'Skills Gained',
             style: TextStyle(
@@ -826,7 +659,6 @@ StreamBuilder(
           
           SizedBox(height: AppConstants.spaceM),
           
-          // Learning Outcomes
           Text(
             'What I Learned',
             style: TextStyle(

--- a/lib/screens/internships/internship_list_screen.dart
+++ b/lib/screens/internships/internship_list_screen.dart
@@ -262,10 +262,13 @@ class _InternshipListScreenState extends State<InternshipListScreen> {
     stream: FirebaseFirestore.instance
         .collection('feedbackRequests')
         .where('internshipId', isEqualTo: internship.id)
-        .limit(1)
         .snapshots(),
     builder: (context, snapshot) {
-      final reviewed = snapshot.hasData && snapshot.data!.docs.isNotEmpty;
+      final hasFeedback = snapshot.hasData &&
+          snapshot.data!.docs.any((doc) {
+            final status = doc['status'] as String?;
+            return status == 'completed';
+          });
 
       return Padding(
         padding: EdgeInsets.only(bottom: AppConstants.spaceM),
@@ -311,25 +314,15 @@ class _InternshipListScreenState extends State<InternshipListScreen> {
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          Row(
-                            children: [
-                              Text(
-                                internship.company,
-                                style: TextStyle(
-                                  fontSize: 18,
-                                  fontWeight: FontWeight.w600,
-                                  color: isDark
-                                      ? AppColors.pureWhite
-                                      : AppColors.pureBlack,
-                                ),
-                              ),
-
-                              if (reviewed) ...[
-                                SizedBox(width: 6),
-                                Icon(Icons.check_circle,
-                                    size: 16, color: Colors.green),
-                              ]
-                            ],
+                          Text(
+                            internship.company,
+                            style: TextStyle(
+                              fontSize: 18,
+                              fontWeight: FontWeight.w600,
+                              color: isDark
+                                  ? AppColors.pureWhite
+                                  : AppColors.pureBlack,
+                            ),
                           ),
 
                           SizedBox(height: 4),

--- a/lib/screens/mentor/mentor_requests_screen.dart
+++ b/lib/screens/mentor/mentor_requests_screen.dart
@@ -1,3 +1,5 @@
+// lib/screens/mentor/mentor_requests_screen.dart
+// FIXED: Works with FeedbackCycle and fetches student/internship info
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
@@ -7,12 +9,47 @@ import '../../core/widgets/glass_container.dart';
 import '../../core/constants/colors.dart';
 import '../../core/constants/app_constants.dart';
 import '../../models/internship_model.dart';
+import '../../models/feedback_cycle_model.dart';
 import 'mentor_internship_detail_screen.dart';
 
 class MentorRequestsScreen extends StatelessWidget {
   MentorRequestsScreen({super.key});
 
   final TextEditingController _feedbackCtrl = TextEditingController();
+  final TextEditingController _nextStepCtrl = TextEditingController();
+
+  // ================= FETCH STUDENT NAME & INTERNSHIP DATA =================
+
+  Future<Map<String, dynamic>> _fetchRequestData(FeedbackCycle cycle) async {
+    try {
+      // Fetch student data
+      final studentDoc = await FirebaseFirestore.instance
+          .collection('users')
+          .doc(cycle.studentId)
+          .get();
+
+      // Fetch internship data
+      final internshipDoc = await FirebaseFirestore.instance
+          .collection('internships')
+          .doc(cycle.internshipId)
+          .get();
+
+      return {
+        'studentName': studentDoc.data()?['displayName'] ?? 'Student',
+        'studentEmail': studentDoc.data()?['email'] ?? '',
+        'company': internshipDoc.data()?['company'] ?? 'Unknown Company',
+        'role': internshipDoc.data()?['role'] ?? '',
+      };
+    } catch (e) {
+      print('Error fetching request data: $e');
+      return {
+        'studentName': 'Student',
+        'studentEmail': '',
+        'company': 'Unknown Company',
+        'role': '',
+      };
+    }
+  }
 
   // ================= VIEW INTERNSHIP =================
 
@@ -76,35 +113,104 @@ class MentorRequestsScreen extends StatelessWidget {
 
   // ================= FEEDBACK DIALOG =================
 
-  void _openFeedbackDialog(BuildContext context, req, bool isDark) {
+  void _openFeedbackDialog(
+    BuildContext context,
+    FeedbackCycle cycle,
+    Map<String, dynamic> requestData,
+    bool isDark,
+  ) {
+    final studentName = requestData['studentName'];
+    final company = requestData['company'];
+
     showDialog(
       context: context,
       builder: (_) => AlertDialog(
+        backgroundColor: isDark
+            ? AppColors.darkGray
+            : AppColors.pureWhite,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
         title: Text(
-          "${req.studentName} requested feedback",
-          style: const TextStyle(fontSize: 20, fontWeight: FontWeight.w700),
+          "$studentName requested feedback",
+          style: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.w700,
+            color: isDark ? AppColors.pureWhite : AppColors.pureBlack,
+          ),
         ),
         content: SingleChildScrollView(
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
             children: [
+              // Company info
+              Row(
+                children: [
+                  Icon(Icons.business, size: 16, color: AppColors.mediumGray),
+                  SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      company,
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w600,
+                        color: isDark ? AppColors.pureWhite : AppColors.pureBlack,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              SizedBox(height: AppConstants.spaceM),
+
+              // Student's request
               Text(
-                "Company: ${req.company}",
-                style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                "Student's Question:",
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                  color: AppColors.mediumGray,
+                ),
               ),
-              const SizedBox(height: 12),
-              const Text(
-                "Student message",
-                style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+              SizedBox(height: 6),
+              Container(
+                padding: EdgeInsets.all(AppConstants.spaceM),
+                decoration: BoxDecoration(
+                  color: AppColors.bluePrimary.withOpacity(0.1),
+                  borderRadius: BorderRadius.circular(12),
+                  border: Border.all(
+                    color: AppColors.bluePrimary.withOpacity(0.3),
+                  ),
+                ),
+                child: Text(
+                  cycle.studentRequest,
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: isDark ? AppColors.pureWhite : AppColors.pureBlack,
+                    height: 1.4,
+                  ),
+                ),
               ),
-              const SizedBox(height: 6),
-              Text(req.message, style: const TextStyle(fontSize: 16)),
-              const SizedBox(height: 20),
+              
+              SizedBox(height: AppConstants.spaceL),
+
+              // Feedback input
+              Text(
+                "Your Feedback:",
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                  color: AppColors.mediumGray,
+                ),
+              ),
+              SizedBox(height: 6),
               TextField(
                 controller: _feedbackCtrl,
-                maxLines: 4,
+                maxLines: 5,
+                style: TextStyle(
+                  color: isDark ? AppColors.pureWhite : AppColors.pureBlack,
+                ),
                 decoration: InputDecoration(
-                  hintText: "Write mentor feedback...",
+                  hintText: "Share your detailed feedback...",
+                  hintStyle: TextStyle(color: AppColors.mediumGray),
                   filled: true,
                   fillColor: isDark
                       ? Colors.white.withOpacity(.05)
@@ -112,6 +218,64 @@ class MentorRequestsScreen extends StatelessWidget {
                   border: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(12),
                     borderSide: BorderSide.none,
+                  ),
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: BorderSide(
+                      color: AppColors.mediumGray.withOpacity(0.2),
+                    ),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: BorderSide(
+                      color: AppColors.bluePrimary,
+                      width: 2,
+                    ),
+                  ),
+                ),
+              ),
+
+              SizedBox(height: AppConstants.spaceM),
+
+              // Next step input (optional)
+              Text(
+                "Suggested Next Step (Optional):",
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                  color: AppColors.mediumGray,
+                ),
+              ),
+              SizedBox(height: 6),
+              TextField(
+                controller: _nextStepCtrl,
+                maxLines: 2,
+                style: TextStyle(
+                  color: isDark ? AppColors.pureWhite : AppColors.pureBlack,
+                ),
+                decoration: InputDecoration(
+                  hintText: "Suggest an action item...",
+                  hintStyle: TextStyle(color: AppColors.mediumGray),
+                  filled: true,
+                  fillColor: isDark
+                      ? Colors.white.withOpacity(.05)
+                      : Colors.black.withOpacity(.05),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: BorderSide.none,
+                  ),
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: BorderSide(
+                      color: AppColors.mediumGray.withOpacity(0.2),
+                    ),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: BorderSide(
+                      color: AppColors.bluePrimary,
+                      width: 2,
+                    ),
                   ),
                 ),
               ),
@@ -122,35 +286,53 @@ class MentorRequestsScreen extends StatelessWidget {
           TextButton(
             onPressed: () {
               _feedbackCtrl.clear();
+              _nextStepCtrl.clear();
               Navigator.pop(context);
             },
-            child: Text("Cancel", style: TextStyle(color: AppColors.mediumGray)),
+            child: Text(
+              "Cancel",
+              style: TextStyle(color: AppColors.mediumGray),
+            ),
           ),
           ElevatedButton(
             style: ElevatedButton.styleFrom(
               backgroundColor: AppColors.bluePrimary,
               foregroundColor: Colors.white,
+              padding: EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
             ),
             onPressed: () async {
-                 if (_feedbackCtrl.text.trim().isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text("Feedback cannot be empty")),
-      );
-      return;
-    }
-              await FirebaseFirestore.instance
-                  .collection('feedbackRequests')
-                  .doc(req.id)
-                  .update({
-                'mentorFeedback': _feedbackCtrl.text.trim(),
-                'status': 'completed',
-                'reviewedAt': Timestamp.now(),
-                'seenByStudent': false, 
-              });
+              if (_feedbackCtrl.text.trim().isEmpty) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text("Feedback cannot be empty")),
+                );
+                return;
+              }
 
-              _feedbackCtrl.clear();
-              Navigator.pop(context);
-             Future.microtask(() => _showSuccess(context));
+              try {
+                // Submit feedback
+                await context.read<MentorProvider>().submitFeedback(
+                      cycleId: cycle.id,
+                      feedback: _feedbackCtrl.text.trim(),
+                      nextStep: _nextStepCtrl.text.trim().isNotEmpty
+                          ? _nextStepCtrl.text.trim()
+                          : null,
+                    );
+
+                _feedbackCtrl.clear();
+                _nextStepCtrl.clear();
+                Navigator.pop(context);
+                Future.microtask(() => _showSuccess(context));
+              } catch (e) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(
+                    content: Text("Error: $e"),
+                    backgroundColor: Colors.red,
+                  ),
+                );
+              }
             },
             child: const Text("Send Feedback"),
           ),
@@ -161,7 +343,12 @@ class MentorRequestsScreen extends StatelessWidget {
 
   // ================= ACTION SHEET =================
 
-  void _openActions(BuildContext context, req, bool isDark) {
+  void _openActions(
+    BuildContext context,
+    FeedbackCycle cycle,
+    Map<String, dynamic> requestData,
+    bool isDark,
+  ) {
     showModalBottomSheet(
       context: context,
       backgroundColor: Colors.transparent,
@@ -172,20 +359,19 @@ class MentorRequestsScreen extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             ListTile(
-              leading:
-                  Icon(Icons.visibility_outlined, color: AppColors.bluePrimary),
+              leading: Icon(Icons.visibility_outlined, color: AppColors.bluePrimary),
               title: const Text("View Internship"),
               onTap: () {
                 Navigator.pop(context);
-                _openInternship(context, req.internshipId);
+                _openInternship(context, cycle.internshipId);
               },
             ),
             ListTile(
               leading: Icon(Icons.edit_outlined, color: AppColors.bluePrimary),
-              title: const Text("Add Review"),
+              title: const Text("Add Feedback"),
               onTap: () {
                 Navigator.pop(context);
-                _openFeedbackDialog(context, req, isDark);
+                _openFeedbackDialog(context, cycle, requestData, isDark);
               },
             ),
           ],
@@ -209,13 +395,28 @@ class MentorRequestsScreen extends StatelessWidget {
             return Center(
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
-                children: const [
-                  Icon(Icons.mark_chat_unread_outlined,
-                      size: 80, color: Colors.grey),
+                children: [
+                  Icon(
+                    Icons.mark_chat_unread_outlined,
+                    size: 80,
+                    color: AppColors.mediumGray.withOpacity(0.5),
+                  ),
                   SizedBox(height: 16),
                   Text(
                     "No feedback requests",
-                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.w500),
+                    style: TextStyle(
+                      fontSize: 20,
+                      fontWeight: FontWeight.w600,
+                      color: isDark ? AppColors.pureWhite : AppColors.pureBlack,
+                    ),
+                  ),
+                  SizedBox(height: 8),
+                  Text(
+                    "Requests from your students will appear here",
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: AppColors.mediumGray,
+                    ),
                   ),
                 ],
               ),
@@ -226,75 +427,133 @@ class MentorRequestsScreen extends StatelessWidget {
             padding: EdgeInsets.all(AppConstants.spaceL),
             itemCount: requests.length,
             itemBuilder: (context, index) {
-              final req = requests[index];
+              final cycle = requests[index];
 
-              return Padding(
-                padding: EdgeInsets.only(bottom: AppConstants.spaceM),
-                child: GestureDetector(
-                  onTap: () => _openActions(context, req, isDark),
-                  child: GlassContainer(
-                    isDark: isDark,
-                    padding: EdgeInsets.all(AppConstants.spaceM),
-                    child: Row(
-                      children: [
-                        Container(
-                          width: 50,
-                          height: 50,
-                          decoration: BoxDecoration(
-                            gradient: LinearGradient(
-                              colors: [
-                                AppColors.bluePrimary,
-                                AppColors.blueLight
-                              ],
-                            ),
-                            borderRadius: BorderRadius.circular(12),
-                          ),
-                          child: Center(
-                            child: Text(
-                              req.studentName.isNotEmpty
-                                  ? req.studentName[0].toUpperCase()
-                                  : "?",
-                              style: const TextStyle(
-                                color: Colors.white,
-                                fontSize: 22,
-                                fontWeight: FontWeight.bold,
+              return FutureBuilder<Map<String, dynamic>>(
+                future: _fetchRequestData(cycle),
+                builder: (context, snapshot) {
+                  if (!snapshot.hasData) {
+                    return Padding(
+                      padding: EdgeInsets.only(bottom: AppConstants.spaceM),
+                      child: GlassContainer(
+                        isDark: isDark,
+                        padding: EdgeInsets.all(AppConstants.spaceM),
+                        child: Center(child: CircularProgressIndicator()),
+                      ),
+                    );
+                  }
+
+                  final requestData = snapshot.data!;
+                  final studentName = requestData['studentName'];
+                  final company = requestData['company'];
+
+                  return Padding(
+                    padding: EdgeInsets.only(bottom: AppConstants.spaceM),
+                    child: GestureDetector(
+                      onTap: () => _openActions(context, cycle, requestData, isDark),
+                      child: GlassContainer(
+                        isDark: isDark,
+                        padding: EdgeInsets.all(AppConstants.spaceM),
+                        child: Row(
+                          children: [
+                            // Avatar
+                            Container(
+                              width: 50,
+                              height: 50,
+                              decoration: BoxDecoration(
+                                gradient: LinearGradient(
+                                  colors: [AppColors.bluePrimary, AppColors.blueLight],
+                                ),
+                                borderRadius: BorderRadius.circular(12),
                               ),
-                            ),
-                          ),
-                        ),
-                        const SizedBox(width: 12),
-                        Expanded(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                req.studentName,
-                                style: const TextStyle(
-                                  fontSize: 17,
-                                  fontWeight: FontWeight.w600,
+                              child: Center(
+                                child: Text(
+                                  studentName.isNotEmpty ? studentName[0].toUpperCase() : "?",
+                                  style: const TextStyle(
+                                    color: Colors.white,
+                                    fontSize: 22,
+                                    fontWeight: FontWeight.bold,
+                                  ),
                                 ),
                               ),
-                              const SizedBox(height: 4),
-                              Text(
-                                "Company: ${req.company}",
-                                style: TextStyle(
-                                  fontSize: 15,
-                                  color: AppColors.mediumGray,
-                                ),
+                            ),
+                            const SizedBox(width: 12),
+                            
+                            // Info
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    studentName,
+                                    style: TextStyle(
+                                      fontSize: 17,
+                                      fontWeight: FontWeight.w600,
+                                      color: isDark ? AppColors.pureWhite : AppColors.pureBlack,
+                                    ),
+                                  ),
+                                  SizedBox(height: 4),
+                                  Row(
+                                    children: [
+                                      Icon(
+                                        Icons.business,
+                                        size: 14,
+                                        color: AppColors.mediumGray,
+                                      ),
+                                      SizedBox(width: 4),
+                                      Expanded(
+                                        child: Text(
+                                          company,
+                                          style: TextStyle(
+                                            fontSize: 15,
+                                            color: AppColors.mediumGray,
+                                          ),
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                  SizedBox(height: 4),
+                                  Text(
+                                    _formatDate(cycle.requestedAt),
+                                    style: TextStyle(
+                                      fontSize: 12,
+                                      color: AppColors.mediumGray,
+                                    ),
+                                  ),
+                                ],
                               ),
-                            ],
-                          ),
+                            ),
+                            
+                            const Icon(Icons.more_horiz, color: AppColors.bluePrimary),
+                          ],
                         ),
-                        const Icon(Icons.more_horiz),
-                      ],
+                      ),
                     ),
-                  ),
-                ),
+                  );
+                },
               );
             },
           );
         },
       ),
     );
+  }
+
+  String _formatDate(DateTime date) {
+    final now = DateTime.now();
+    final diff = now.difference(date);
+
+    if (diff.inDays == 0) {
+      if (diff.inHours == 0) {
+        return '${diff.inMinutes}m ago';
+      }
+      return '${diff.inHours}h ago';
+    } else if (diff.inDays == 1) {
+      return 'Yesterday';
+    } else if (diff.inDays < 7) {
+      return '${diff.inDays}d ago';
+    } else {
+      return '${date.day}/${date.month}/${date.year}';
+    }
   }
 }

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -51,10 +51,10 @@ class AuthService {
       if (role == 'mentor' && invitation != null) {
         await _mentorService.createMentorLink(
           mentorId: user.uid,
-          studentId: invitation.studentId,
-          studentName: invitation.studentName,
-          studentEmail: invitation.studentEmail,
-          inviteId: invitation.id,
+          studentId: invitation['studentId'] as String,
+          studentName: invitation['studentName'] as String,
+          studentEmail: invitation['studentEmail'] as String,
+          inviteId: invitation['id'] as String,
         );
       }
 

--- a/lib/services/feedback_service.dart
+++ b/lib/services/feedback_service.dart
@@ -1,0 +1,149 @@
+// lib/services/feedback_service.dart
+// FIXED: Better error handling and logging
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../models/feedback_cycle_model.dart';
+
+class FeedbackService {
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+
+  // Get latest feedback cycle for an internship
+  Future<FeedbackCycle?> getLatestFeedback(String internshipId) async {
+    try {
+      print('FeedbackService: Getting latest feedback for internship: $internshipId');
+      
+      final snapshot = await _firestore
+          .collection('feedbackCycles')
+          .where('internshipId', isEqualTo: internshipId)
+          .orderBy('requestedAt', descending: true)
+          .limit(1)
+          .get();
+
+      if (snapshot.docs.isEmpty) {
+        print('FeedbackService: No feedback found for internship: $internshipId');
+        return null;
+      }
+      
+      print('FeedbackService: Found ${snapshot.docs.length} feedback cycle(s)');
+      return FeedbackCycle.fromFirestore(snapshot.docs.first);
+    } catch (e) {
+      print('FeedbackService ERROR getting latest feedback: $e');
+      // Don't throw, return null to show "no feedback" state
+      return null;
+    }
+  }
+
+  // Get all feedback history for an internship
+  Stream<List<FeedbackCycle>> getFeedbackHistory(String internshipId) {
+    print('FeedbackService: Streaming feedback history for internship: $internshipId');
+    
+    return _firestore
+        .collection('feedbackCycles')
+        .where('internshipId', isEqualTo: internshipId)
+        .orderBy('requestedAt', descending: true)
+        .snapshots()
+        .handleError((error) {
+          print('FeedbackService ERROR in history stream: $error');
+        })
+        .map((snapshot) {
+          print('FeedbackService: Received ${snapshot.docs.length} feedback cycles in history');
+          return snapshot.docs
+              .map((doc) => FeedbackCycle.fromFirestore(doc))
+              .toList();
+        });
+  }
+
+  // Create a new feedback request
+  Future<void> createFeedbackRequest({
+    required String internshipId,
+    required String studentId,
+    required String mentorId,
+    required String studentRequest,
+  }) async {
+    try {
+      print('FeedbackService: Creating feedback request...');
+      print('  internshipId: $internshipId');
+      print('  studentId: $studentId');
+      print('  mentorId: $mentorId');
+      
+      final cycle = FeedbackCycle(
+        id: '',
+        internshipId: internshipId,
+        studentId: studentId,
+        mentorId: mentorId,
+        studentRequest: studentRequest,
+        status: 'pending',
+        requestedAt: DateTime.now(),
+      );
+
+      final docRef = await _firestore
+          .collection('feedbackCycles')
+          .add(cycle.toFirestore());
+      
+      print('FeedbackService: Successfully created feedback request with ID: ${docRef.id}');
+    } catch (e) {
+      print('FeedbackService ERROR creating feedback request: $e');
+      throw 'Failed to create feedback request: $e';
+    }
+  }
+
+  // Mark feedback as seen by student
+  Future<void> markFeedbackAsSeen(String cycleId) async {
+    try {
+      print('FeedbackService: Marking feedback as seen: $cycleId');
+      
+      await _firestore.collection('feedbackCycles').doc(cycleId).update({
+        'seenByStudent': true,
+      });
+      
+      print('FeedbackService: Successfully marked as seen');
+    } catch (e) {
+      print('FeedbackService ERROR marking feedback as seen: $e');
+      // Don't throw - this is not critical
+    }
+  }
+
+  // Update feedback with mentor response
+  Future<void> submitMentorFeedback({
+    required String cycleId,
+    required String feedback,
+    String? nextStep,
+  }) async {
+    try {
+      print('FeedbackService: Submitting mentor feedback for cycle: $cycleId');
+      
+      await _firestore.collection('feedbackCycles').doc(cycleId).update({
+        'mentorFeedback': feedback,
+        'suggestedNextStep': nextStep,
+        'status': 'completed',
+        'respondedAt': Timestamp.now(),
+        'seenByStudent': false,
+      });
+      
+      print('FeedbackService: Successfully submitted mentor feedback');
+    } catch (e) {
+      print('FeedbackService ERROR submitting mentor feedback: $e');
+      throw 'Failed to submit feedback: $e';
+    }
+  }
+
+  // Get pending feedback cycles for a mentor
+  Stream<List<FeedbackCycle>> getMentorPendingRequests(String mentorId) {
+    print('FeedbackService: Streaming pending requests for mentor: $mentorId');
+    
+    return _firestore
+        .collection('feedbackCycles')
+        .where('mentorId', isEqualTo: mentorId)
+        .where('status', isEqualTo: 'pending')
+        .orderBy('requestedAt', descending: true)
+        .snapshots()
+        .handleError((error) {
+          print('FeedbackService ERROR in mentor requests stream: $error');
+        })
+        .map((snapshot) {
+          print('FeedbackService: Received ${snapshot.docs.length} pending requests for mentor');
+          return snapshot.docs
+              .map((doc) => FeedbackCycle.fromFirestore(doc))
+              .toList();
+        });
+  }
+}

--- a/lib/services/mentor_service.dart
+++ b/lib/services/mentor_service.dart
@@ -1,107 +1,77 @@
+// lib/services/mentor_service.dart
+// FIXED: Now uses feedbackCycles collection instead of feedbackRequests
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '../models/mentor_invitation_model.dart';
 import '../models/internship_model.dart';
-import '../models/feedback_request_model.dart';
+import '../models/feedback_cycle_model.dart';
 
 class MentorService {
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
 
-  // Send mentor invitation
-  Future<void> sendInvitation({
-    required String studentId,
-    required String studentName,
-    required String studentEmail,
-    required String mentorEmail,
-  }) async {
-    final invitation = MentorInvitation(
-      id: '',
-      studentId: studentId,
-      studentName: studentName,
-      studentEmail: studentEmail,
-      mentorEmail: mentorEmail,
-      status: InvitationStatus.pending,
-      createdAt: DateTime.now(),
-    );
-
-    await _firestore.collection('mentorInvites').add(invitation.toFirestore());
-  }
-
-  Future<MentorInvitation?> checkInvitation(String email) async {
-    final snapshot = await _firestore
-        .collection('mentorInvites')
-        .where('mentorEmail', isEqualTo: email)
+  // ==================== FEEDBACK CYCLES (NEW) ====================
+  
+  /// Get pending feedback cycles for a mentor
+  /// This replaces the old getMentorRequests that used feedbackRequests collection
+  Stream<List<FeedbackCycle>> getMentorPendingCycles(String mentorId) {
+    print('MentorService: Streaming pending cycles for mentor: $mentorId');
+    
+    return _firestore
+        .collection('feedbackCycles')
+        .where('mentorId', isEqualTo: mentorId)
         .where('status', isEqualTo: 'pending')
-        .limit(1)
-        .get();
-
-    if (snapshot.docs.isEmpty) return null;
-    return MentorInvitation.fromFirestore(snapshot.docs.first);
+        .orderBy('requestedAt', descending: true)
+        .snapshots()
+        .handleError((error) {
+          print('MentorService ERROR in pending cycles stream: $error');
+        })
+        .map((snapshot) {
+          print('MentorService: Received ${snapshot.docs.length} pending cycles');
+          return snapshot.docs
+              .map((doc) => FeedbackCycle.fromFirestore(doc))
+              .toList();
+        });
   }
 
-  Future<void> createMentorLink({
-    required String mentorId,
-    required String studentId,
-    required String studentName,
-    required String studentEmail,
-    required String inviteId,
+  /// Submit mentor feedback for a cycle
+  Future<void> submitFeedback({
+    required String cycleId,
+    required String feedback,
+    String? nextStep,
   }) async {
-    final link = MentorStudentLink(
-      id: '',
-      mentorId: mentorId,
-      studentId: studentId,
-      studentName: studentName,
-      studentEmail: studentEmail,
-      linkedAt: DateTime.now(),
-    );
-
-    await _firestore.collection('mentorStudentLinks').add(link.toFirestore());
-
-    await _firestore.collection('mentorInvites').doc(inviteId).update({
-      'status': 'accepted',
-      'respondedAt': Timestamp.now(),
-    });
+    try {
+      print('MentorService: Submitting feedback for cycle: $cycleId');
+      
+      await _firestore.collection('feedbackCycles').doc(cycleId).update({
+        'mentorFeedback': feedback,
+        'suggestedNextStep': nextStep,
+        'status': 'completed',
+        'respondedAt': Timestamp.now(),
+        'seenByStudent': false,
+      });
+      
+      print('MentorService: Successfully submitted feedback');
+    } catch (e) {
+      print('MentorService ERROR submitting feedback: $e');
+      throw 'Failed to submit feedback: $e';
+    }
   }
 
+  // ==================== STUDENTS MANAGEMENT ====================
+
+  /// Get stream of mentor's students
   Stream<List<MentorStudentLink>> getStudentsStream(String mentorId) {
     return _firestore
         .collection('mentorStudentLinks')
         .where('mentorId', isEqualTo: mentorId)
-        .orderBy('linkedAt', descending: true)
         .snapshots()
-        .map((s) =>
-            s.docs.map((d) => MentorStudentLink.fromFirestore(d)).toList());
+        .map((snapshot) {
+      return snapshot.docs
+          .map((doc) => MentorStudentLink.fromFirestore(doc))
+          .toList();
+    });
   }
 
-  // Feedback Requests
-
-  Future<String?> getMentorIdByEmail(String email) async {
-    final res = await _firestore
-        .collection('users')
-        .where('email', isEqualTo: email)
-        .where('role', isEqualTo: 'mentor')
-        .limit(1)
-        .get();
-
-    if (res.docs.isEmpty) return null;
-    return res.docs.first.id;
-  }
-
-  Future<void> createFeedbackRequest(Map<String, dynamic> data) async {
-    await _firestore.collection('feedbackRequests').add(data);
-  }
-
-  Stream<List<FeedbackRequest>> getMentorRequests(String mentorId) {
-    return _firestore
-        .collection('feedbackRequests')
-        .where('mentorId', isEqualTo: mentorId)
-        .where('status', isEqualTo: 'pending')
-        .snapshots()
-        .map((snap) =>
-            snap.docs.map((d) => FeedbackRequest.fromFirestore(d)).toList());
-  }
-
-  // Internships
-
+  /// Get stream of a specific student's internships
   Stream<List<Internship>> getStudentInternshipsStream(String studentId) {
     return _firestore
         .collection('internships')
@@ -109,17 +79,152 @@ class MentorService {
         .where('isArchived', isEqualTo: false)
         .orderBy('appliedDate', descending: true)
         .snapshots()
-        .map((s) => s.docs.map((d) => Internship.fromFirestore(d)).toList());
+        .map((snapshot) {
+      return snapshot.docs
+          .map((doc) => Internship.fromFirestore(doc))
+          .toList();
+    });
   }
 
-  Future<bool> isMentorLinkedToStudent(String mentorId, String studentId) async {
-    final snapshot = await _firestore
-        .collection('mentorStudentLinks')
-        .where('mentorId', isEqualTo: mentorId)
-        .where('studentId', isEqualTo: studentId)
-        .limit(1)
-        .get();
+  // ==================== INVITATIONS ====================
 
-    return snapshot.docs.isNotEmpty;
+  /// Check if there's a pending invitation for the given email
+  /// Returns the invitation data if found, null otherwise
+  Future<Map<String, dynamic>?> checkInvitation(String email) async {
+    try {
+      print('MentorService: Checking invitation for email: $email');
+      
+      final snapshot = await _firestore
+          .collection('mentorInvites')
+          .where('mentorEmail', isEqualTo: email.trim().toLowerCase())
+          .where('status', isEqualTo: 'pending')
+          .limit(1)
+          .get();
+
+      if (snapshot.docs.isEmpty) {
+        print('MentorService: No pending invitation found');
+        return null;
+      }
+
+      print('MentorService: Found pending invitation');
+      return snapshot.docs.first.data();
+    } catch (e) {
+      print('MentorService ERROR checking invitation: $e');
+      return null;
+    }
+  }
+
+  /// Create mentor-student link from an invitation
+  Future<void> createMentorLink({
+    required String mentorId,
+    required String studentId,
+    required String studentName,
+    required String studentEmail,
+    required String inviteId,
+  }) async {
+    try {
+      print('MentorService: Creating mentor link...');
+      print('  mentorId: $mentorId');
+      print('  studentId: $studentId');
+
+      // Get mentor email
+      final mentorDoc = await _firestore.collection('users').doc(mentorId).get();
+      if (!mentorDoc.exists) {
+        throw 'Mentor user not found';
+      }
+      final mentorEmail = mentorDoc.data()?['email'] ?? '';
+
+      // Create the mentor-student link
+      await _firestore.collection('mentorStudentLinks').add({
+        'mentorId': mentorId,
+        'mentorEmail': mentorEmail,
+        'studentId': studentId,
+        'studentName': studentName,
+        'studentEmail': studentEmail,
+        'linkedAt': Timestamp.now(),
+      });
+
+      // Update invitation status
+      await _firestore.collection('mentorInvites').doc(inviteId).update({
+        'status': 'accepted',
+        'mentorId': mentorId,
+        'acceptedAt': Timestamp.now(),
+      });
+
+      print('MentorService: Successfully created mentor link');
+    } catch (e) {
+      print('MentorService ERROR creating mentor link: $e');
+      throw 'Failed to create mentor link: $e';
+    }
+  }
+
+  /// Send mentor invitation
+  Future<void> sendInvitation({
+    required String studentId,
+    required String studentName,
+    required String studentEmail,
+    required String mentorEmail,
+  }) async {
+    try {
+      // Check if mentor exists
+      final mentorSnapshot = await _firestore
+          .collection('users')
+          .where('email', isEqualTo: mentorEmail)
+          .where('role', isEqualTo: 'mentor')
+          .limit(1)
+          .get();
+
+      if (mentorSnapshot.docs.isEmpty) {
+        throw 'No mentor found with email: $mentorEmail';
+      }
+
+      final mentorId = mentorSnapshot.docs.first.id;
+
+      // Check if link already exists
+      final existingLink = await _firestore
+          .collection('mentorStudentLinks')
+          .where('studentId', isEqualTo: studentId)
+          .where('mentorId', isEqualTo: mentorId)
+          .limit(1)
+          .get();
+
+      if (existingLink.docs.isNotEmpty) {
+        throw 'Already linked with this mentor';
+      }
+
+      // Create the link
+      await _firestore.collection('mentorStudentLinks').add({
+        'studentId': studentId,
+        'studentName': studentName,
+        'studentEmail': studentEmail,
+        'mentorId': mentorId,
+        'mentorEmail': mentorEmail,
+        'linkedAt': Timestamp.now(),
+      });
+
+      // Create notification/invitation record (optional)
+      await _firestore.collection('mentorInvites').add({
+        'studentId': studentId,
+        'studentName': studentName,
+        'studentEmail': studentEmail,
+        'mentorEmail': mentorEmail,
+        'mentorId': mentorId,
+        'status': 'accepted',
+        'sentAt': Timestamp.now(),
+      });
+    } catch (e) {
+      print('MentorService ERROR sending invitation: $e');
+      throw e;
+    }
+  }
+
+  /// Remove mentor-student link
+  Future<void> removeMentorLink(String linkId) async {
+    try {
+      await _firestore.collection('mentorStudentLinks').doc(linkId).delete();
+    } catch (e) {
+      print('MentorService ERROR removing link: $e');
+      throw 'Failed to remove mentor link: $e';
+    }
   }
 }


### PR DESCRIPTION
### **User description**
- Replace stacked feedback thread with single active feedback cycle
- Show only latest mentor feedback on internship detail screen
- Add clear empty state when no feedback exists
- Move historical feedback to dedicated feedback history screen
- Keep internship detail page short, scannable, and structured
- Align mentor feedback interaction with cycle-based product logic

Closes #36


___

### **PR Type**
Enhancement


___

### **Description**
- Refactor mentor feedback system from stacked threads to cycle-based model

- Replace old feedbackRequests with new feedbackCycles collection structure

- Show only latest feedback on internship detail, move history to dedicated screen

- Add request feedback screen for students to initiate feedback cycles

- Update mentor dashboard and requests screen to work with new feedback cycles


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Student"] -->|"Request Feedback"| B["RequestFeedbackScreen"]
  B -->|"Create Cycle"| C["FeedbackCycles Collection"]
  C -->|"Notify"| D["Mentor"]
  D -->|"Submit Response"| E["MentorRequestsScreen"]
  E -->|"Update Cycle"| C
  C -->|"Show Latest"| F["MentorFeedbackWidget"]
  C -->|"Show History"| G["FeedbackHistoryScreen"]
  F -->|"Display on"| H["InternshipDetailScreen"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>feedback_cycle_model.dart</strong><dd><code>New feedback cycle data model with Firestore serialization</code></dd></td>
  <td><a href="https://github.com/kalviumcommunity/S62-122025-Binary-FlutterFirebase-InternTrack/pull/37/files#diff-be602ae88ad69750c3caed0734885d9d628a20917171671dfe7cf6f21fecfd4f">+64/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mentor_provider.dart</strong><dd><code>Update provider to use feedback cycles instead of requests</code></dd></td>
  <td><a href="https://github.com/kalviumcommunity/S62-122025-Binary-FlutterFirebase-InternTrack/pull/37/files#diff-2b73f5e47da4a22cafd92050422055cc40d4e1bf3a5d2106d4bda81d13581ccb">+46/-16</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>feedback_history_screen.dart</strong><dd><code>New screen displaying all historical feedback cycles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kalviumcommunity/S62-122025-Binary-FlutterFirebase-InternTrack/pull/37/files#diff-2986049af7a77dd631f886d1a1d197ebdeb2b3da8127c75628dfe32f279ad7ce">+389/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>request_feedback_screen.dart</strong><dd><code>New screen for students to request mentor feedback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kalviumcommunity/S62-122025-Binary-FlutterFirebase-InternTrack/pull/37/files#diff-42502c49d7be30f32c398e9f69e7ee19c2c8838b4304293a688991c7ea07cf94">+401/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>mentor_feedback_widget.dart</strong><dd><code>Reusable widget showing latest feedback with empty and pending states</code></dd></td>
  <td><a href="https://github.com/kalviumcommunity/S62-122025-Binary-FlutterFirebase-InternTrack/pull/37/files#diff-7e52a33a40fda62379b5e2bbbad2b8facf7d4f909eb94eabaec5729d73511d7f">+450/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>internship_detail_screen.dart</strong><dd><code>Replace old feedback section with new mentor feedback widget</code></dd></td>
  <td><a href="https://github.com/kalviumcommunity/S62-122025-Binary-FlutterFirebase-InternTrack/pull/37/files#diff-4a4a50e1ec036559669a86f3cd8592581c4a725fdbf8dd39839c61dc43a72fd2">+31/-199</a></td>

</tr>

<tr>
  <td><strong>internship_list_screen.dart</strong><dd><code>Update feedback status check to use completed cycles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kalviumcommunity/S62-122025-Binary-FlutterFirebase-InternTrack/pull/37/files#diff-2ce7fa3b0f0204dd613bdd51b1f32b73d0dab8c1482322dfdaf493cce6e969e7">+14/-21</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>mentor_requests_screen.dart</strong><dd><code>Refactor to work with feedback cycles and fetch student/internship </code><br><code>data</code></dd></td>
  <td><a href="https://github.com/kalviumcommunity/S62-122025-Binary-FlutterFirebase-InternTrack/pull/37/files#diff-fe8404ef112e66e081e8826791b8b3c78932f66d08dad2cbbc36776668ea44a4">+361/-102</a></td>

</tr>

<tr>
  <td><strong>feedback_service.dart</strong><dd><code>New service for managing feedback cycles with Firestore operations</code></dd></td>
  <td><a href="https://github.com/kalviumcommunity/S62-122025-Binary-FlutterFirebase-InternTrack/pull/37/files#diff-2bf54fc4bd35c1010ccf3c8a8efc853b75e4037e6b9718a1c8546f8aec8115f6">+149/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>mentor_service.dart</strong><dd><code>Migrate from feedbackRequests to feedbackCycles collection</code></dd></td>
  <td><a href="https://github.com/kalviumcommunity/S62-122025-Binary-FlutterFirebase-InternTrack/pull/37/files#diff-cddc53b3c2aa5c9f3ed02b850c6d9437549756e8668351947273990e68e625f8">+199/-94</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>mentor_dashboard.dart</strong><dd><code>Fix initialization lifecycle and improve request tab handling</code></dd></td>
  <td><a href="https://github.com/kalviumcommunity/S62-122025-Binary-FlutterFirebase-InternTrack/pull/37/files#diff-70b285cde5f242d1103076fe9a93c0e612483f74ca42524544f7bfa8d133f3bd">+76/-66</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>auth_service.dart</strong><dd><code>Fix invitation data type casting in mentor link creation</code>&nbsp; </dd></td>
  <td><a href="https://github.com/kalviumcommunity/S62-122025-Binary-FlutterFirebase-InternTrack/pull/37/files#diff-8414b6daed2de6e3d3cd13091e3111414474d32187fb56552b36aed2331785ac">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

